### PR TITLE
FIX : Remove CR in Window

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update && apt-get install -y \
 	openssl \
 	libssl-dev
 
+
 RUN chmod +x /app/Server/install_dependency.sh
 RUN chmod +x /app/Server/generate_code.sh
 
+RUN sed -i 's/\r$//' install_dependency.sh
 RUN /app/Server/install_dependency.sh
 # CMD /app/Server/generate_code.sh
 


### PR DESCRIPTION
# Issue
- 윈도우의 파일 내에서 줄 바꿈으로 인하여 실행파일이 시작이 안되었음.
- 다음의 명령어를 통하여 문제 해결
```
sed -i 's/\r$//' install_dependency.sh
```